### PR TITLE
fix typo in the ColorHSV documentation text

### DIFF
--- a/ColorManager/Colors/ColorHSV.cs
+++ b/ColorManager/Colors/ColorHSV.cs
@@ -3,7 +3,7 @@
 namespace ColorManager
 {
     /// <summary>
-    /// Stores information and values of the HSL color model
+    /// Stores information and values of the HSV color model
     /// </summary>
     public sealed class ColorHSV : ColorHSx
     {


### PR DESCRIPTION
Fixed a simple typo (HSL -> HSV)